### PR TITLE
Remove tiny stack from retrieval metadata output

### DIFF
--- a/dependency/retrieval/components/dependency.go
+++ b/dependency/retrieval/components/dependency.go
@@ -49,12 +49,11 @@ func ConvertReleaseToDependency(release Release) (cargo.ConfigMetadataDependency
 
 	stacks := []string{
 		"io.buildpacks.stacks.bionic",
-		"io.paketo.stacks.tiny",
 	}
 
 	c, _ := semver.NewConstraint("3.1.*")
 	if !(c.Check(release.SemVer)) {
-		stacks = append(stacks, "io.buildpacks.stacks.jammy", "io.buildpacks.stacks.jammy.tiny")
+		stacks = append(stacks, "io.buildpacks.stacks.jammy")
 	}
 
 	depDate, err := time.ParseInLocation("2006-01-02", release.EOLDate, time.UTC)

--- a/dependency/retrieval/components/dependency_test.go
+++ b/dependency/retrieval/components/dependency_test.go
@@ -133,9 +133,7 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 				SourceSHA256:    "",
 				Stacks: []string{
 					"io.buildpacks.stacks.bionic",
-					"io.paketo.stacks.tiny",
 					"io.buildpacks.stacks.jammy",
-					"io.buildpacks.stacks.jammy.tiny",
 				},
 				StripComponents: 0,
 				URI:             server.URL,
@@ -184,7 +182,6 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 					SourceSHA256:    "",
 					Stacks: []string{
 						"io.buildpacks.stacks.bionic",
-						"io.paketo.stacks.tiny",
 					},
 					StripComponents: 0,
 					URI:             server.URL,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The .NET runtime isn't yet compatible with the Tiny stacks. See [this exploration](https://github.com/paketo-community/explorations/blob/2fe5033e6bffa108f6a05333c430929012e76c32/dotnet-on-tiny/README.md) for a deep dive into why not. We shouldn't mark the dependency as compatible with the tiny stacks.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
